### PR TITLE
fix: Add typing and ascMain

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
         "asbuild": "npm run asbuild:optimized",
         "test": "asp --verbose"
     },
+    "typing": "assembly/crypto.ts",
+    "ascMain": "assembly/crypto.ts",
     "devDependencies": {
         "@as-pect/cli": "^6.2.0",
         "assemblyscript": "^0.19.3"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "asbuild": "npm run asbuild:optimized",
         "test": "asp --verbose"
     },
-    "typing": "assembly/crypto.ts",
+    "types": "assembly/crypto.ts",
     "ascMain": "assembly/crypto.ts",
     "devDependencies": {
         "@as-pect/cli": "^6.2.0",


### PR DESCRIPTION
These fields make tsc and asc know where the entry file is. Should fix issues like this [one](https://github.com/petersalomonsen/NFT/pull/5/files#diff-16e6dd4a865b494fd85113e547c26cced5c871bac70782170dea98d48a0bc508R3):
```ts
import { sha256HashInit } from '../../../node_modules/wasm-crypto/assembly/crypto'; // -> 'wasm-crypto'
```